### PR TITLE
Change messages ids to be the same as the ones from Checkout API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Changed
+
+- Change messages ids to be the same as the ones from Checkout API
+
 ## [0.4.4] - 2019-09-11
 
 ## Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,6 +3,6 @@
   "store/coupon.ApplyPromoCode": "Apply Promo Code",
   "store/coupon.PromoCode": "Promo Code",
   "store/coupon.PromoCodeLabel": "Promo Code",
-  "store/coupon.CodeDoesntExist": "Invalid Promo Code.",
-  "store/coupon.ExpiredPromoCode": "This Promo Code has expired."
+  "store/coupon.couponNotFound": "Invalid Promo Code.",
+  "store/coupon.couponExpired": "This Promo Code has expired."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,6 @@
   "store/coupon.ApplyPromoCode": "Apply Promo Code",
   "store/coupon.PromoCode": "Promo Code",
   "store/coupon.PromoCodeLabel": "Promo Code",
-  "store/coupon.CodeDoesntExist": "Invalid Promo Code.",
-  "store/coupon.ExpiredPromoCode": "This Promo Code has expired."
+  "store/coupon.couponNotFound": "Invalid Promo Code.",
+  "store/coupon.couponExpired": "This Promo Code has expired."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,6 +3,6 @@
   "store/coupon.ApplyPromoCode": "Aplicar Cupón de Descuento",
   "store/coupon.PromoCode": "Cupón de Descuento",
   "store/coupon.PromoCodeLabel": "Código de Cupón",
-  "store/coupon.CodeDoesntExist": "Este Cupón no es válido.",
-  "store/coupon.ExpiredPromoCode": "Este Cupón ha expirado."
+  "store/coupon.couponNotFound": "Este Cupón no es válido.",
+  "store/coupon.couponExpired": "Este Cupón ha expirado."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,6 +3,6 @@
   "store/coupon.ApplyPromoCode": "Aplicar Cupom de Desconto",
   "store/coupon.PromoCode": "Cupom de Desconto",
   "store/coupon.PromoCodeLabel": "Código do Cupom",
-  "store/coupon.CodeDoesntExist": "Cupom inválido.",
-  "store/coupon.ExpiredPromoCode": "Cupom expirado."
+  "store/coupon.couponNotFound": "Cupom inválido.",
+  "store/coupon.couponExpired": "Cupom expirado."
 }

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -13,12 +13,12 @@ defineMessages({
     id: 'store/coupon.ApplyPromoCode',
     defaultMessage: 'Apply Promo Code',
   },
-  CodeDoesntExist: {
-    id: 'store/coupon.CodeDoesntExist',
+  couponNotFound: {
+    id: 'store/coupon.couponNotFound',
     defaultMessage: `Invalid Promo Code.`,
   },
-  ExpiredPromoCode: {
-    id: 'store/coupon.ExpiredPromoCode',
+  couponExpired: {
+    id: 'store/coupon.couponExpired',
     defaultMessage: `This Promo Code has expired.`,
   },
   PromoCode: {


### PR DESCRIPTION
#### What problem is this solving?

The messages code returned by the Checkout API were different than the ones defined on Checkout-coupon. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

```
cd react
yarn test
```

[Workspace](https://marketingdata--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
