### PR TITLE
Use FormattedMessage and add ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,57 +7,65 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Styleguide components ids.
+
+### Changed
+
+- Use `FormattedMesage` instead of `intl`.
+
 ## [0.5.0] - 2019-10-14
 
 ## [0.4.7] - 2019-10-11
 
-## Changed
+### Changed
 
 - Component bevahior on blur when it has no content
 
 ## [0.4.6] - 2019-10-01
 
-## Changed
+### Changed
 
 - Button's label style
 
 ## [0.4.5] - 2019-09-11
 
-## Changed
+### Changed
 
 - Change messages ids to be the same as the ones from Checkout API
 
 ## [0.4.4] - 2019-09-11
 
-## Fixed
+### Fixed
 
 - Incorrect message id on defineMessages
 
 ## [0.4.3] - 2019-09-06
 
-## Changes
+### Changed
 
 - Intl entries
 
 ## [0.4.2] - 2019-09-05
 
-## Added
+### Added
 
 - Unit tests
 
 ## [0.4.1] - 2019-08-29
 
-## Added
+### Added
 
 - UI manipulation related functions
 
 ## [0.4.0] - 2019-08-26
 
-## Removed
+### Removed
 
 - All the component's logic
 
-## Added
+### Added
 
 - Consuming Order-coupon provider
 - Internationalization
@@ -66,14 +74,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.2.0] - 2019-08-16
 
-## Added
+### Added
 
 - Component ui details
 - Button with icon in order to close the input
 
 ## [0.1.0] - 2019-08-13
 
-## Added
+### Added
 
 - Coupon Component
 - Interface to be used by other apps

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,8 +1,0 @@
-{
-  "store/coupon.Apply": "Apply",
-  "store/coupon.ApplyPromoCode": "Apply Promo Code",
-  "store/coupon.PromoCode": "Promo Code",
-  "store/coupon.PromoCodeLabel": "Promo Code",
-  "store/coupon.couponNotFound": "Invalid Promo Code.",
-  "store/coupon.couponExpired": "This Promo Code has expired."
-}

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -1,41 +1,12 @@
 import React, { Fragment } from 'react'
-import { defineMessages, injectIntl, InjectedIntlProps } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import { Button, Input, Tag } from 'vtex.styleguide'
 
 import { useOrderCoupon } from 'vtex.order-coupon/OrderCoupon'
 
-defineMessages({
-  Apply: {
-    id: 'store/coupon.Apply',
-    defaultMessage: 'Apply',
-  },
-  ApplyPromoCode: {
-    id: 'store/coupon.ApplyPromoCode',
-    defaultMessage: 'Apply Promo Code',
-  },
-  couponNotFound: {
-    id: 'store/coupon.couponNotFound',
-    defaultMessage: `Invalid Promo Code.`,
-  },
-  couponExpired: {
-    id: 'store/coupon.couponExpired',
-    defaultMessage: `This Promo Code has expired.`,
-  },
-  PromoCode: {
-    id: 'store/coupon.PromoCode',
-    defaultMessage: 'Promo Code',
-  },
-  PromoCodeLabel: {
-    id: 'store/coupon.PromoCode',
-    defaultMessage: 'Promo Code',
-  },
-})
-
 const NO_ERROR = ''
 
-const Coupon: StorefrontFunctionComponent<CouponProps & InjectedIntlProps> = ({
-  intl,
-}) => {
+const Coupon: StorefrontFunctionComponent = () => {
   const toggle = () => setShowPromoButton(!showPromoButton)
 
   const {
@@ -52,6 +23,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps & InjectedIntlProps> = ({
     evt.preventDefault()
     const newCoupon = evt.target.value.trim()
     if (!newCoupon) {
+      setErrorKey(NO_ERROR)
       toggle()
     }
   }
@@ -80,8 +52,13 @@ const Coupon: StorefrontFunctionComponent<CouponProps & InjectedIntlProps> = ({
         <Fragment>
           {!coupon && (
             <div className="mb5">
-              <Button variation="tertiary" collapseLeft noUpperCase onClick={toggle}>
-                {intl.formatMessage({ id: `store/coupon.ApplyPromoCode` })}
+              <Button
+                variation="tertiary"
+                collapseLeft
+                noUpperCase
+                onClick={toggle}
+              >
+                <FormattedMessage id="store/coupon.ApplyPromoCode" />
               </Button>
             </div>
           )}
@@ -89,7 +66,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps & InjectedIntlProps> = ({
           {coupon && (
             <div className="mb6">
               <div className="c-on-base t-small mb3">
-                {intl.formatMessage({ id: `store/coupon.PromoCode` })}
+                <FormattedMessage id="store/coupon.PromoCode" />
               </div>
               <Tag onClick={resetCouponInput}>{coupon}</Tag>
             </div>
@@ -103,17 +80,17 @@ const Coupon: StorefrontFunctionComponent<CouponProps & InjectedIntlProps> = ({
             onBlur={handleBlur}
             placeholder=""
             errorMessage={
-              errorKey
-                ? intl.formatMessage({
-                    id: `store/coupon.${errorKey}`,
-                  })
-                : NO_ERROR
+              errorKey ? (
+                <FormattedMessage id={`store/coupon.${errorKey}`} />
+              ) : (
+                NO_ERROR
+              )
             }
-            label={intl.formatMessage({ id: `store/coupon.PromoCodeLabel` })}
+            label={<FormattedMessage id="store/coupon.PromoCodeLabel" />}
             value={coupon}
             suffix={
               <Button variation="secondary" size="small" type="submit">
-                {intl.formatMessage({ id: `store/coupon.Apply` })}
+                <FormattedMessage id="store/coupon.Apply" />
               </Button>
             }
           />
@@ -123,8 +100,4 @@ const Coupon: StorefrontFunctionComponent<CouponProps & InjectedIntlProps> = ({
   )
 }
 
-interface CouponProps {
-  intl: object
-}
-
-export default injectIntl(Coupon)
+export default Coupon

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -53,6 +53,7 @@ const Coupon: StorefrontFunctionComponent = () => {
           {!coupon && (
             <div className="mb5">
               <Button
+                id="add-coupon"
                 variation="tertiary"
                 collapseLeft
                 noUpperCase
@@ -68,13 +69,16 @@ const Coupon: StorefrontFunctionComponent = () => {
               <div className="c-on-base t-small mb3">
                 <FormattedMessage id="store/coupon.PromoCode" />
               </div>
-              <Tag onClick={resetCouponInput}>{coupon}</Tag>
+              <Tag id="coupon-code" onClick={resetCouponInput}>
+                {coupon}
+              </Tag>
             </div>
           )}
         </Fragment>
       ) : (
         <form className="mb6" onSubmit={submitCoupon}>
           <Input
+            id="coupon-input"
             autoFocus
             onChange={handleCouponChange}
             onBlur={handleBlur}
@@ -89,7 +93,12 @@ const Coupon: StorefrontFunctionComponent = () => {
             label={<FormattedMessage id="store/coupon.PromoCodeLabel" />}
             value={coupon}
             suffix={
-              <Button variation="secondary" size="small" type="submit">
+              <Button
+                id="apply-coupon"
+                variation="secondary"
+                size="small"
+                type="submit"
+              >
                 <FormattedMessage id="store/coupon.Apply" />
               </Button>
             }


### PR DESCRIPTION
#### What problem is this solving?

In order to do e2e tests, the html elements need to have an identifier. Besides that, this PR also adds the use of `FormattedMessage` component.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://testid--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24034/adicionar-atributo-testid-em-elementos-da-ui)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->