### PR TITLE
Fix coupon error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Show coupon error message.
+
 ## [0.5.1] - 2019-10-15
 
 ### Added

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -1,10 +1,37 @@
 import React, { Fragment } from 'react'
-import { FormattedMessage } from 'react-intl'
+import { defineMessages, FormattedMessage } from 'react-intl'
 import { Button, Input, Tag } from 'vtex.styleguide'
 
 import { useOrderCoupon } from 'vtex.order-coupon/OrderCoupon'
 
 const NO_ERROR = ''
+
+defineMessages({
+  Apply: {
+    id: 'store/coupon.Apply',
+    defaultMessage: 'Apply',
+  },
+  ApplyPromoCode: {
+    id: 'store/coupon.ApplyPromoCode',
+    defaultMessage: 'Apply Promo Code',
+  },
+  couponNotFound: {
+    id: 'store/coupon.couponNotFound',
+    defaultMessage: `Invalid Promo Code.`,
+  },
+  couponExpired: {
+    id: 'store/coupon.couponExpired',
+    defaultMessage: `This Promo Code has expired.`,
+  },
+  PromoCode: {
+    id: 'store/coupon.PromoCode',
+    defaultMessage: 'Promo Code',
+  },
+  PromoCodeLabel: {
+    id: 'store/coupon.PromoCode',
+    defaultMessage: 'Promo Code',
+  },
+})
 
 const Coupon: StorefrontFunctionComponent = () => {
   const toggle = () => setShowPromoButton(!showPromoButton)


### PR DESCRIPTION
#### What problem is this solving?

As the title says, when an invalid coupon code was inserted, it was not showing the proper error message.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://fixcoupon--vtexgame1.myvtex.com/cart)
- Insert any invalid coupon code
- Verify if the message "Invalid coupon code" is presented.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/25015/erro-do-cupom-com-texto-quebrado)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/67591700-62d50b00-f734-11e9-8661-32eb5e8fd3c2.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

