### PR TITLE
Removes order-coupon dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `order-coupon` dependency.
+
 ## [0.7.0] - 2019-11-06
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.styleguide": "9.x",
-    "vtex.order-coupon": "0.x"
+    "vtex.styleguide": "9.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -1,8 +1,6 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useState } from 'react'
 import { defineMessages, FormattedMessage } from 'react-intl'
 import { ButtonPlain, InputButton, Tag } from 'vtex.styleguide'
-
-import { useOrderCoupon } from 'vtex.order-coupon/OrderCoupon'
 
 const NO_ERROR = ''
 
@@ -33,18 +31,15 @@ defineMessages({
   },
 })
 
-const Coupon: StorefrontFunctionComponent = () => {
+const Coupon: StorefrontFunctionComponent<CouponProps> = ({
+  coupon,
+  insertCoupon,
+  couponErrorKey,
+}) => {
+  const [showPromoButton, setShowPromoButton] = useState(true)
+  const [errorKey, setErrorKey] = useState(couponErrorKey)
+  const [currentCoupon, setCurrentCoupon] = useState(coupon)
   const toggle = () => setShowPromoButton(!showPromoButton)
-
-  const {
-    coupon,
-    setCoupon,
-    insertCoupon,
-    showPromoButton,
-    setShowPromoButton,
-    errorKey,
-    setErrorKey,
-  } = useOrderCoupon()
 
   const handleBlur = (evt: any) => {
     evt.preventDefault()
@@ -58,26 +53,33 @@ const Coupon: StorefrontFunctionComponent = () => {
   const handleCouponChange = (evt: any) => {
     evt.preventDefault()
     const newCoupon = evt.target.value.trim()
-    setCoupon(newCoupon)
+    setCurrentCoupon(newCoupon)
   }
 
   const resetCouponInput = () => {
     insertCoupon('')
-    setCoupon('')
+    setCurrentCoupon('')
     setShowPromoButton(false)
   }
 
   const submitCoupon = (evt: any) => {
     evt.preventDefault()
     setErrorKey(NO_ERROR)
-    insertCoupon(coupon)
+    insertCoupon(currentCoupon).then((result: boolean) => {
+      if (result) {
+        setErrorKey(NO_ERROR)
+        setShowPromoButton(true)
+      } else {
+        setErrorKey(couponErrorKey)
+      }
+    })
   }
 
   return (
     <Fragment>
       {showPromoButton ? (
         <Fragment>
-          {!coupon && (
+          {!currentCoupon && (
             <div>
               <ButtonPlain id="add-coupon" onClick={toggle}>
                 <FormattedMessage id="store/coupon.ApplyPromoCode" />
@@ -85,13 +87,13 @@ const Coupon: StorefrontFunctionComponent = () => {
             </div>
           )}
 
-          {coupon && (
+          {currentCoupon && (
             <div>
               <div className="c-on-base t-small mb3">
                 <FormattedMessage id="store/coupon.PromoCode" />
               </div>
               <Tag id="coupon-code" onClick={resetCouponInput}>
-                {coupon}
+                {currentCoupon}
               </Tag>
             </div>
           )}
@@ -114,12 +116,18 @@ const Coupon: StorefrontFunctionComponent = () => {
               )
             }
             label={<FormattedMessage id="store/coupon.PromoCodeLabel" />}
-            value={coupon}
+            value={currentCoupon}
           />
         </form>
       )}
     </Fragment>
   )
+}
+
+interface CouponProps {
+  coupon: string
+  insertCoupon: (coupon: string) => Promise<boolean>
+  couponErrorKey: string
 }
 
 export default Coupon

--- a/react/__tests__/Coupon.test.tsx
+++ b/react/__tests__/Coupon.test.tsx
@@ -1,17 +1,13 @@
-import { render } from '@vtex/test-tools/react'
+import { render, fireEvent } from '@vtex/test-tools/react'
 import React from 'react'
 import Coupon from '../Coupon'
-import { OrderCouponContext } from 'vtex.order-coupon/OrderCoupon'
 
 const promoButtonText = 'Apply Promo Code'
+const applyButtonText = 'Apply'
 
 describe('<Coupon />', () => {
   const renderComponent = (customProps: any) => {
-    const wrapper = render(
-      <OrderCouponContext.Provider value={customProps}>
-        <Coupon />
-      </OrderCouponContext.Provider>
-    )
+    const wrapper = render(<Coupon {...customProps} />)
     return wrapper
   }
 
@@ -23,7 +19,6 @@ describe('<Coupon />', () => {
   it('should show apply promo button', () => {
     const { getByText } = renderComponent({
       coupon: '',
-      showPromoButton: true,
     })
 
     const element = getByText(promoButtonText)
@@ -34,16 +29,17 @@ describe('<Coupon />', () => {
   it('should show input when showPromoButton is false', () => {
     const { getByText } = renderComponent({
       coupon: '',
-      showPromoButton: false,
     })
 
-    expect(getByText('Apply')).toBeTruthy()
+    const button = getByText(promoButtonText)
+    fireEvent.click(button)
+
+    expect(getByText(applyButtonText)).toBeTruthy()
   })
 
   it('should show coupon tag', () => {
     const { getByText } = renderComponent({
       coupon: 'testcoupon',
-      showPromoButton: true,
     })
 
     expect(getByText('testcoupon')).toBeTruthy()


### PR DESCRIPTION
#### What problem is this solving?

This PR removes the `order-coupon` dependency that this UI component had. Now, all the orchestrators will communicate to `checkout-cart` that, in turn, will pass all the needed info to the UI components.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to the [Workspace](https://buttonloading--checkoutio.myvtex.com/cart)
- Try to insert a coupon
- Verify if its all working normally

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
