### PR TITLE
Show spinner while waiting for the coupon insertion result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Spinner to the input in order to give the user a feedback of loading.
+
 ## [0.8.0] - 2019-11-08
 
 ### Removed

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -39,6 +39,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
   const [showPromoButton, setShowPromoButton] = useState(true)
   const [errorKey, setErrorKey] = useState(couponErrorKey)
   const [currentCoupon, setCurrentCoupon] = useState(coupon)
+  const [loadingCoupon, setLoadingCoupon] = useState(false)
   const toggle = () => setShowPromoButton(!showPromoButton)
 
   const handleBlur = (evt: any) => {
@@ -66,6 +67,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
     evt.preventDefault()
     setErrorKey(NO_ERROR)
     insertCoupon(currentCoupon).then((result: boolean) => {
+      setLoadingCoupon(false)
       if (result) {
         setErrorKey(NO_ERROR)
         setShowPromoButton(true)
@@ -73,6 +75,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
         setErrorKey(couponErrorKey)
       }
     })
+    setLoadingCoupon(true)
   }
 
   return (
@@ -103,7 +106,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
           <InputButton
             id="coupon-input"
             button={<FormattedMessage id="store/coupon.Apply" />}
-            isLoading={false}
+            isLoading={loadingCoupon}
             autoFocus
             onChange={handleCouponChange}
             onBlur={handleBlur}


### PR DESCRIPTION
#### What problem is this solving?

We need to provide to the user a feedback for him to know if he actually triggered the insertion. This PR adds it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://productskeleton--checkoutio.myvtex.com/cart)
- Insert a coupon
- Verify if an icon of loading is showed.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
