### PR TITLE
Remove coupon errorKey prop in order to avoid inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `errorKey` prop in order to avoid inconsistency, since it was kept on both `order-coupon` and `checkout-coupon`.
+
 ## [0.9.0] - 2019-11-11
 
 ### Added

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -70,7 +70,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
   const submitCoupon = (evt: any) => {
     evt.preventDefault()
     setErrorKey(NO_ERROR)
-    insertCoupon(currentCoupon).then((result: any) => {
+    insertCoupon(currentCoupon).then((result: InsertCouponResult) => {
       setLoadingCoupon(false)
       if (result.success) {
         setErrorKey(NO_ERROR)

--- a/react/Coupon.tsx
+++ b/react/Coupon.tsx
@@ -2,6 +2,11 @@ import React, { Fragment, useState } from 'react'
 import { defineMessages, FormattedMessage } from 'react-intl'
 import { ButtonPlain, InputButton, Tag } from 'vtex.styleguide'
 
+interface InsertCouponResult {
+  success: boolean
+  errorKey: string
+}
+
 const NO_ERROR = ''
 
 defineMessages({
@@ -34,11 +39,10 @@ defineMessages({
 const Coupon: StorefrontFunctionComponent<CouponProps> = ({
   coupon,
   insertCoupon,
-  couponErrorKey,
 }) => {
   const [showPromoButton, setShowPromoButton] = useState(true)
-  const [errorKey, setErrorKey] = useState(couponErrorKey)
-  const [currentCoupon, setCurrentCoupon] = useState(coupon)
+  const [errorKey, setErrorKey] = useState(NO_ERROR)
+  const [currentCoupon, setCurrentCoupon] = useState('')
   const [loadingCoupon, setLoadingCoupon] = useState(false)
   const toggle = () => setShowPromoButton(!showPromoButton)
 
@@ -66,13 +70,13 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
   const submitCoupon = (evt: any) => {
     evt.preventDefault()
     setErrorKey(NO_ERROR)
-    insertCoupon(currentCoupon).then((result: boolean) => {
+    insertCoupon(currentCoupon).then((result: any) => {
       setLoadingCoupon(false)
-      if (result) {
+      if (result.success) {
         setErrorKey(NO_ERROR)
         setShowPromoButton(true)
       } else {
-        setErrorKey(couponErrorKey)
+        setErrorKey(result.errorKey)
       }
     })
     setLoadingCoupon(true)
@@ -82,7 +86,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
     <Fragment>
       {showPromoButton ? (
         <Fragment>
-          {!currentCoupon && (
+          {!coupon && (
             <div>
               <ButtonPlain id="add-coupon" onClick={toggle}>
                 <FormattedMessage id="store/coupon.ApplyPromoCode" />
@@ -90,13 +94,13 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
             </div>
           )}
 
-          {currentCoupon && (
+          {coupon && (
             <div>
               <div className="c-on-base t-small mb3">
                 <FormattedMessage id="store/coupon.PromoCode" />
               </div>
               <Tag id="coupon-code" onClick={resetCouponInput}>
-                {currentCoupon}
+                {coupon}
               </Tag>
             </div>
           )}
@@ -129,8 +133,7 @@ const Coupon: StorefrontFunctionComponent<CouponProps> = ({
 
 interface CouponProps {
   coupon: string
-  insertCoupon: (coupon: string) => Promise<boolean>
-  couponErrorKey: string
+  insertCoupon: (coupon: string) => Promise<InsertCouponResult>
 }
 
 export default Coupon


### PR DESCRIPTION
#### What problem is this solving?

Since `couponErrorKey` value was being kept both on `order-coupon` and `checkout-coupon`, it was causing some inconsistency problems. This PR fix it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://fixcouponerror--checkoutio.myvtex.com/cart)
- Try to insert a coupon
- Verify if its working normally

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

